### PR TITLE
Revert AZs to input from variables. 

### DIFF
--- a/asg.tf
+++ b/asg.tf
@@ -14,7 +14,6 @@ resource "aws_launch_configuration" "launch_configuration" {
 # Create ASG and assing launch configration to it
 resource "aws_autoscaling_group" "autoscaling_group" {
   name                 = "${var.tags["Environment"]}-${var.tags["Application"]}-${var.tags["Tier"]}-${var.name}-ASG"
-  availability_zones   = ["${data.aws_availability_zones.service_azs.names}"]
   launch_configuration = "${aws_launch_configuration.launch_configuration.id}"
   max_size             = "${var.asg_size_max}"
   min_size             = "${var.asg_size_min}"

--- a/subnets.tf
+++ b/subnets.tf
@@ -4,13 +4,13 @@ resource "aws_subnet" "subnets" {
   count                   = "${length(var.subnets_cidr)}"
   vpc_id                  = "${var.vpc_id}"
   cidr_block              = "${var.subnets_cidr[count.index]}"
-  availability_zone       = "${element(data.aws_availability_zones.service_azs.names, count.index)}"
+  availability_zone       = "${element(var.availability_zones, count.index)}"
   map_public_ip_on_launch = "${var.subnets_map_public_ip_on_launch}"
 
   tags {
     # Tagging policy requests ${element(var.availability_zones, count.index)} be converted into "EW/1A" style
     # We can look this up, or we can suggest that this format is not optimal
-    Name = "${var.tags["Environment"]}-${var.tags["Application"]}-${var.tags["Tier"]}-${var.name}-SUB-${element(data.aws_availability_zones.service_azs.names, count.index)}"
+    Name = "${var.tags["Environment"]}-${var.tags["Application"]}-${var.tags["Tier"]}-${var.name}-SUB-${element(var.availability_zones, count.index)}"
 
     # Can we just inherit the master tags list from var_input.tf here?
     Environment = "${var.tags["Environment"]}"

--- a/var_input.tf
+++ b/var_input.tf
@@ -1,6 +1,3 @@
-### Dynamic data
-data "aws_availability_zones" "service_azs" {}
-
 ### Module inputs ###
 variable "asg_health_check_grace_period" {
   type        = "string"


### PR DESCRIPTION
 Revert AZs to input from variables. Data source to be used at a higher level module. Also remove availability_zones from ASG config as it is redundant when vpc_zone_identifier is present
